### PR TITLE
Improve KT analysis for phases

### DIFF
--- a/crit_app/figures.py
+++ b/crit_app/figures.py
@@ -487,6 +487,8 @@ def make_kill_time_graph(
     Returns:
         Figure: Plotly figure object displaying the kill time graph.
     """
+    # Phase-aware kill time
+    kill_time_seconds = party_rotation_dataclass.fight_duration
     x = [
         kill_time_seconds - x.seconds_shortened
         for x in party_rotation_dataclass.shortened_rotations

--- a/crit_app/job_data/encounter_data.py
+++ b/crit_app/job_data/encounter_data.py
@@ -56,8 +56,8 @@ encounter_phases = {
     #     6: "P6: Alpha Omega",
     # }
 }
-
 custom_t_clip_encounter_phases = {1079: [1, 2, 3, 4]}
+skip_kill_time_analysis_phases = {1079: [2, 3]}
 
 # Used for Party analysis
 boss_hp = {

--- a/crit_app/job_data/encounter_data.py
+++ b/crit_app/job_data/encounter_data.py
@@ -57,6 +57,8 @@ encounter_phases = {
     # }
 }
 
+custom_t_clip_encounter_phases = {1079: [1, 2, 3, 4]}
+
 # Used for Party analysis
 boss_hp = {
     88: 36660084,

--- a/crit_app/pages/party_analysis.py
+++ b/crit_app/pages/party_analysis.py
@@ -35,10 +35,12 @@ from crit_app.figures import (
     make_rotation_pdf_figure,
 )
 from crit_app.job_data.encounter_data import (
+    custom_t_clip_encounter_phases,
     encounter_level,
+    skip_kill_time_analysis_phases,
     stat_ranges,
     valid_encounters,
-)  # ensure stat_ranges is accessible
+)
 from crit_app.job_data.job_data import caster_healer_strength, weapon_delays
 from crit_app.job_data.roles import (
     abbreviated_job_map,
@@ -167,6 +169,7 @@ def layout(party_analysis_id=None):
         ### FFLogs Card Elements ###
         ############################
 
+        perform_kill_time_analysis = party_analysis_obj.perform_kill_time_analysis
         kill_time_str = format_kill_time_str(kill_time)
 
         phase_selector_options, phase_select_hidden = get_phase_selector_options(
@@ -225,7 +228,11 @@ def layout(party_analysis_id=None):
         )
 
         party_dps_figure = make_party_rotation_pdf_figure(party_analysis_obj)
-        kill_time_figure = make_kill_time_graph(party_analysis_obj, kill_time)
+        kill_time_figure = (
+            make_kill_time_graph(party_analysis_obj, kill_time)
+            if perform_kill_time_analysis
+            else None
+        )
         player_analysis_selector_options = [
             {
                 "label": html.Span(
@@ -251,7 +258,11 @@ def layout(party_analysis_id=None):
 
         results_card = create_results_card(
             analysis_url,
+            encounter_name,
+            party_analysis_obj.fight_duration,
+            phase_id,
             party_dps_figure,
+            perform_kill_time_analysis,
             kill_time_figure,
             player_analysis_selector_options,
             player_analysis_selector[0][2],
@@ -1050,7 +1061,19 @@ def analyze_party_rotation(
 
     # FIXME: this needs to be found for fights like FRU
     # Fixed time between phases, need to find killing damage event
+    find_t_clip_offset = False
+    perform_kill_time_analysis = True
+
+    if encounter_id in custom_t_clip_encounter_phases.keys():
+        if fight_phase in custom_t_clip_encounter_phases[encounter_id]:
+            find_t_clip_offset = True
+
+    if encounter_id in skip_kill_time_analysis_phases.keys():
+        if fight_phase in skip_kill_time_analysis_phases[encounter_id]:
+            perform_kill_time_analysis = False
+
     t_clips = [2.5, 5, 7.5, 10]
+    t_clip_offset = 0
     # Damage step size for
     n_data_points = 5000
 
@@ -1119,7 +1142,7 @@ def analyze_party_rotation(
         level,
         etro_url,
         player_analysis_ids,
-        t_clips,
+        # t_clips,
     )
 
     if success:
@@ -1127,9 +1150,6 @@ def analyze_party_rotation(
             job_rotation_analyses_list,
             job_rotation_pdf_list,
             job_db_rows,
-            job_rotation_clipping_pdf_list,
-            job_rotation_clipping_analyses,
-            t_clips,
         ) = results
 
     else:
@@ -1137,6 +1157,47 @@ def analyze_party_rotation(
         insert_error_player_analysis(*results)
         return updated_url, [error_alert(error_message)]
 
+    if perform_kill_time_analysis:
+        if find_t_clip_offset:
+            t_clip_offset = calculate_time_clip_offset(job_rotation_analyses_list)
+
+        clipping_success, clipping_results = create_rotation_clippings(
+            report_id,
+            fight_id,
+            encounter_name,
+            encounter_id,
+            player_name,
+            player_id,
+            fight_phase,
+            job,
+            main_stat_no_buff,
+            main_stat_multiplier,
+            secondary_stat_no_buff,
+            speed,
+            determination,
+            crit,
+            dh,
+            weapon_damage,
+            medication_amt,
+            level,
+            player_analysis_ids,
+            t_clips,
+            t_clip_offset,
+            job_rotation_analyses_list,
+        )
+
+        if clipping_success:
+            (
+                job_rotation_clipping_pdf_list,
+                job_rotation_clipping_analyses,
+            ) = clipping_results
+        else:
+            error_message = clipping_results[-2]
+            insert_error_player_analysis(*clipping_results)
+            return updated_url, [error_alert(error_message)]
+    else:
+        job_rotation_clipping_pdf_list = [None] * len(job)
+        job_rotation_clipping_analyses = [None] * len(job)
     ########################
     # Party-level analysis
     ########################
@@ -1150,6 +1211,8 @@ def analyze_party_rotation(
             lb_damage_events_df,
             party_analysis_id,
             t_clips,
+            t_clip_offset,
+            perform_kill_time_analysis,
             n_data_points,
             level,
         )
@@ -1267,7 +1330,6 @@ def player_analysis_loop(
     level: int,
     etro_url: List[str],
     player_analysis_ids: List[Optional[str]],
-    t_clips: List[float],
 ) -> Tuple[
     bool,
     Union[
@@ -1454,23 +1516,75 @@ def player_analysis_loop(
             if role in ("Healer", "Magical Ranged"):
                 actions_df = actions_df[actions_df["ability_name"] != "attack"]
 
-            # We have to get a little cute here because it's possible for to return an empty rotation
-            # If that's the case, we just want to skip over it and not append it, so individual lists
-            # of each dataclass are created and appended to if a rotation is returned.
-            t_out = []
-
-        # Phases often include a lot of downtime, which messes up t_clip because
-        # nothing happens during then.
-        # Find the "end" of the phase, marked by the final hit by anyone
-        final_action_time = max(
-            [t.actions_df["timestamp"].iloc[-1] for t in job_rotation_analyses_list]
+        success = True
+        return (
+            success,
+            (
+                job_rotation_analyses_list,
+                job_rotation_pdf_list,
+                job_db_rows,
+            ),
         )
-        t_clip_offset = (
-            job_rotation_analyses_list[0].fight_end_time - final_action_time
-        ) / 1000
 
-        t_clips = [float(t + t_clip_offset) for t in t_clips]
+    except Exception as e:
+        success = False
+        player_error_info = (
+            report_id,
+            fight_id,
+            player_id[a],
+            encounter_id,
+            encounter_name,
+            fight_phase,
+            full_job,
+            player_name[a],
+            int(main_stat_no_buff[a]),
+            int(main_stat_buff),
+            main_stat_type,
+            None if secondary_stat_no_buff[a] == "None" else secondary_stat_no_buff[a],
+            secondary_stat_buff,
+            secondary_stat_type,
+            int(determination[a]),
+            int(speed[a]),
+            int(crit[a]),
+            int(dh[a]),
+            int(weapon_damage[a]),
+            delay,
+            medication_amt,
+            main_stat_multiplier,
+            str(e),
+            traceback.format_exc(),
+        )
+        return success, (player_error_info)
 
+
+def create_rotation_clippings(
+    report_id: str,
+    fight_id: int,
+    encounter_name: str,
+    encounter_id: int,
+    player_name: List[str],
+    player_id: List[int],
+    fight_phase: int,
+    job: List[str],
+    main_stat_no_buff: List[float],
+    main_stat_multiplier: float,
+    secondary_stat_no_buff: List[Union[float, str]],
+    speed: List[int],
+    determination: List[int],
+    crit: List[int],
+    dh: List[int],
+    weapon_damage: List[int],
+    medication_amt: int,
+    level: int,
+    player_analysis_ids: List[Optional[str]],
+    t_clips: List[float],
+    t_clip_offset: float,
+    job_rotation_analyses_list,
+):
+    rotation_dmg_step = LEVEL_STEP_MAP[level]["rotation_dmg_step"]
+    action_delta = LEVEL_STEP_MAP[level]["action_delta"]
+    rotation_delta = LEVEL_STEP_MAP[level]["rotation_delta"]
+    try:
         # Job rotation clippings to unconvolve out later
         job_rotation_clipping_pdf_list = {t: [] for t in t_clips}
         job_rotation_clipping_analyses = {t: [] for t in t_clips}
@@ -1507,7 +1621,7 @@ def player_analysis_loop(
                 clipped_rotations.append(
                     job_rotation_analyses_list[a].make_rotation_df(
                         actions_df,
-                        t_end_clip=t,
+                        t_end_clip=t + t_clip_offset,
                         return_clipped=True,
                     )
                 )
@@ -1539,17 +1653,12 @@ def player_analysis_loop(
                     job_rotation_clipping_pdf_list[t].append(
                         job_rotation_clipping_analyses[t][-1]
                     )
-                    t_out.append(t)
         success = True
         return (
             success,
             (
-                job_rotation_analyses_list,
-                job_rotation_pdf_list,
-                job_db_rows,
                 job_rotation_clipping_pdf_list,
                 job_rotation_clipping_analyses,
-                t_clips,
             ),
         )
 
@@ -1582,6 +1691,7 @@ def player_analysis_loop(
             traceback.format_exc(),
         )
         return success, (player_error_info)
+    pass
 
 
 def party_analysis_portion(
@@ -1593,6 +1703,8 @@ def party_analysis_portion(
     lb_damage_events_df: pd.DataFrame,
     party_analysis_id: Optional[str],
     t_clips: List[float],
+    t_clip_offset: float,
+    perform_kill_time_analysis: bool,
     n_data_points: int,
     level: int,
 ) -> "PartyRotation":
@@ -1621,18 +1733,25 @@ def party_analysis_portion(
 
     rotation_pdf, rotation_supp = rotation_dps_pdf(job_rotation_pdf_list, lb_damage)
 
-    truncated_party_distribution, party_distribution_clipping = kill_time_analysis(
-        job_rotation_analyses_list,
-        job_rotation_pdf_list,
-        lb_damage_events_df,
-        job_rotation_clipping_analyses,
-        job_rotation_clipping_pdf_list,
-        rotation_pdf,
-        rotation_supp,
-        t_clips,
-        rotation_dmg_step,
-    )
-
+    if perform_kill_time_analysis:
+        truncated_party_distribution, party_distribution_clipping = kill_time_analysis(
+            job_rotation_analyses_list,
+            job_rotation_pdf_list,
+            lb_damage_events_df,
+            job_rotation_clipping_analyses,
+            job_rotation_clipping_pdf_list,
+            rotation_pdf,
+            rotation_supp,
+            t_clips,
+            rotation_dmg_step,
+        )
+    else:
+        truncated_party_distribution = {
+            t: {"pdf": [1, 0], "support": [1, 0]} for t in t_clips
+        }
+        party_distribution_clipping = {
+            t: {"pdf": [1, 0], "support": [1, 0]} for t in t_clips
+        }
     #
     boss_total_hp = (
         sum([a.actions_df["amount"].sum() for a in job_rotation_analyses_list])
@@ -1648,10 +1767,27 @@ def party_analysis_portion(
         ]
     ) / sum([a.rotation_variance ** (3 / 2) for a in job_rotation_pdf_list])
 
+    # FIXME: have fight/phase duration
+    # and active dps time
+    active_dps_time = job_rotation_analyses_list[0].fight_time
+
+    if job_rotation_analyses_list[0].phase > 0:
+        fight_duration = (
+            job_rotation_analyses_list[0].phase_end_time
+            - job_rotation_analyses_list[0].phase_start_time
+        ) / 1000
+    else:
+        fight_duration = (
+            job_rotation_analyses_list[0].fight_end_time
+            - job_rotation_analyses_list[0].fight_start_time
+        ) / 1000
+
     party_rotation = PartyRotation(
         party_analysis_id,
         boss_total_hp,
-        job_rotation_analyses_list[0].fight_time,
+        active_dps_time,
+        fight_duration,
+        perform_kill_time_analysis,
         lb_damage_events_df,
         party_mean,
         party_std,
@@ -1661,6 +1797,7 @@ def party_analysis_portion(
         [
             SplitPartyRotation(
                 t,
+                t_clip_offset,
                 boss_total_hp,
                 truncated_party_distribution[t]["pdf"],
                 truncated_party_distribution[t]["support"],
@@ -1676,3 +1813,36 @@ def party_analysis_portion(
     )
 
     return party_rotation
+
+
+def calculate_time_clip_offset(job_rotation_analyses_list: List[Any]) -> float:
+    """
+    Calculate the time clip offset to account for downtime phases in combat analysis.
+
+    Phases in combat often include significant downtime where no actions occur,
+    which can skew the time clipping (`t_clip`) calculations. This function
+    identifies the end of active combat by locating the timestamp of the final
+    action performed by any player and computes the offset needed to adjust
+    the clipping time accordingly.
+
+    Args:
+        job_rotation_analyses_list (List[Any]):
+            A list of job rotation analysis objects. Each object is expected to have
+            an `actions_df` attribute, which is a pandas DataFrame containing
+            a `'timestamp'` column, and a `fight_end_time` attribute representing
+            the end time of the fight in milliseconds.
+
+    Returns:
+        float:
+            The computed time clip offset in seconds. This offset adjusts for
+            the downtime by calculating the difference between the fight's end
+            time and the timestamp of the last action, then converting it from
+            milliseconds to seconds.
+    """
+    final_action_time = max(
+        [t.actions_df["timestamp"].iloc[-1] for t in job_rotation_analyses_list]
+    )
+    t_clip_offset = (
+        float(job_rotation_analyses_list[0].fight_end_time - final_action_time) / 1000
+    )
+    return t_clip_offset

--- a/crit_app/party_cards.py
+++ b/crit_app/party_cards.py
@@ -10,6 +10,7 @@ from dash import (
 
 from crit_app.job_data.encounter_data import stat_ranges
 from crit_app.job_data.roles import abbreviated_job_map, role_stat_dict
+from crit_app.shared_elements import format_kill_time_str
 
 QUICK_BUILD_TABLE_STYLES = {
     "header": {
@@ -333,20 +334,67 @@ def create_fflogs_card(
 
 def create_results_card(
     analysis_url: str = "",
+    encounter_name: str = "",
+    encounter_duration: float = 0,
+    encounter_phase: int = 0,
     party_dps_pdf_figure=None,
+    perform_kill_time_analysis: bool = True,
     kill_time_figure=None,
-    player_analysis_selector_options=[],
+    player_analysis_selector_options=None,
     player_analysis_default=None,
 ):
+    """
+    Creates a card layout for party analysis, including DPS distributions,.
+
+    kill time analysis, and job-level graphs.
+
+    Args:
+        analysis_url (str):
+            The URL for referencing or sharing this party analysis. Displayed
+            as a disabled input to copy from.
+        encounter_name (str):
+            Name/title of the encounter (e.g. "E4S: Titan").
+        encounter_duration (float):
+            Total duration of the encounter in seconds.
+        encounter_phase (int):
+            Phase of the encounter being analyzed. Defaults to 0.
+        party_dps_pdf_figure:
+            A Plotly figure object showing the party DPS distribution.
+        perform_kill_time_analysis (bool):
+            Whether to display kill-time probability. Defaults to True.
+        kill_time_figure:
+            A Plotly figure object for kill-time distribution.
+        player_analysis_selector_options (list):
+            Options for selecting a job/player to view analysis details.
+        player_analysis_default:
+            Default selection for the job-level analysis dropdown.
+
+    Returns:
+        dbc.Card:
+            A Bootstrap card containing the entire party analysis: summary,
+            DPS distribution charts, optional kill time analysis, and
+            job-level distribution viewer.
+    """
+
+    kill_time_string = format_kill_time_str(encounter_duration)
+    if encounter_phase == 0:
+        fight_info_string = f"{encounter_name} ({kill_time_string})"
+    else:
+        fight_info_string = f"{encounter_name} P{encounter_phase} ({kill_time_string})"
+
     party_analysis_summary = html.Div(
         [
             dbc.Row(
                 [
                     html.P(
                         [
-                            "Scroll down to see a detailed analysis showing the DPS distribution of the party's rotation, how likely faster kill times are, and individual player DPS distributions. Click ",
+                            "Scroll down to see a detailed analysis showing the DPS "
+                            "distribution of the party's rotation, how likely faster "
+                            "kill times are, and individual player DPS distributions. "
+                            "Click ",
                             html.A("here", href="#", id="party-analysis-open"),
-                            " to learn more about the limitations and assumptions of the results.",
+                            " to learn more about the limitations and assumptions of "
+                            "the results.",
                             party_analysis_assumptions_modal,
                         ]
                     ),
@@ -381,33 +429,51 @@ def create_results_card(
         ]
     )
 
-    # Party rotation DPS distribution
     party_dps_pdf = dbc.Card(
         dbc.CardBody(
             [
                 html.H3("Party DPS distribution"),
                 html.P(
-                    "The graph below shows the DPS distribution for the whole party. Mouse over curves/points to view corresponding percentiles."
+                    "The graph below shows the DPS distribution for the whole "
+                    "party. Mouse over curves/points to view corresponding "
+                    "percentiles."
                 ),
                 dcc.Graph(figure=party_dps_pdf_figure),
             ]
         )
     )
 
-    # Kill time analysis
+    if perform_kill_time_analysis:
+        kill_time_children = [
+            html.P(
+                "The graph below estimates how likely the actual kill time was "
+                "and how likely faster kill times might be. The y-axis "
+                "represents all kills that are equal to or faster than the "
+                "kill time on the x-axis. Faster kill times are estimated by "
+                "truncating the rotation of the party. Note the log scale."
+            ),
+            html.P(
+                "Low percent chances indicate that faster kill times with the "
+                "given rotation are unlikely. Improve rotation, consistency, or "
+                "use more Limit Break to achieve faster kills."
+            ),
+            dcc.Graph(figure=kill_time_figure),
+        ]
+    else:
+        kill_time_children = [
+            html.P(
+                "A kill time analysis was not performed because the selected "
+                "phase has a fixed duration."
+            )
+        ]
+
     kill_time_card = html.Div(
         dbc.Card(
             dbc.CardBody(
                 html.Div(
                     [
                         html.H3("Kill time analysis"),
-                        html.P(
-                            "The graph below estimates how likely the actual kill time was and how likely faster kill times are. The y-axis represents all kills that are equal to or faster than the kill time reported on the x-axis. Faster kill times are estimated by simply truncating the rotation of the party by the respective time amount. Note the y-axis is on a log scale."
-                        ),
-                        html.P(
-                            "Low percent chances indicate that faster kill times with the given rotation are unlikely. Faster kill times may be achieved through means like further refining the party's rotation, performing a planned rotation more consistently, or generating more Limit Break usages."
-                        ),
-                        dcc.Graph(figure=kill_time_figure),
+                        *kill_time_children,
                     ]
                 )
             )
@@ -430,9 +496,7 @@ def create_results_card(
                 player_analysis_selector_options,
                 value=player_analysis_default,
                 id="job-selector",
-                style={
-                    "height": "45px",
-                },
+                style={"height": "45px"},
             ),
             html.Br(),
         ],
@@ -445,7 +509,11 @@ def create_results_card(
                     [
                         html.H3("Job damage distributions"),
                         html.P(
-                            "Click the drop-down to view the DPS distribution of a specific job. The radio buttons toggle between the overall rotation DPS distribution and the DPS distribution of each action. Mouse over curves/points to view corresponding percentiles."
+                            "Use the dropdown to view a particular job's DPS "
+                            "distribution. The radio buttons toggle between "
+                            "the overall rotation DPS distribution and the "
+                            "action-by-action distribution. Mouse over curves "
+                            "to see percentiles."
                         ),
                         html.A(
                             [
@@ -473,7 +541,7 @@ def create_results_card(
     return dbc.Card(
         dbc.CardBody(
             [
-                html.H2("Party analysis results"),
+                html.H2(f"Analysis for {fight_info_string}"),
                 party_analysis_summary,
                 html.Br(),
                 party_dps_pdf,

--- a/crit_app/party_cards.py
+++ b/crit_app/party_cards.py
@@ -265,7 +265,7 @@ def create_fflogs_card(
                     medication_selector,
                     quick_build_div,
                     party_accordion,
-                    buttons,
+                    # buttons,
                 ],
                 id="party-list-collapse",
                 is_open=False,
@@ -293,7 +293,7 @@ def create_fflogs_card(
             medication_selector,
             quick_build_div,
             party_accordion,
-            buttons,
+            # buttons,
         ]
 
     fflogs_hidden_div = html.Div(
@@ -301,6 +301,7 @@ def create_fflogs_card(
             encounter_info,
             phase_select,
             *job_build_items,
+            buttons,
             *party_analysis_progress,
             html.Div(id="party-analysis-error"),
         ],

--- a/crit_app/util/db.py
+++ b/crit_app/util/db.py
@@ -777,7 +777,7 @@ def get_party_analysis_encounter_info(
     con = sqlite3.connect(DB_URI)
     cur = con.cursor()
     cur.execute(sql_query, params)
-
+    # FIXME: check if none, redirect 404
     (
         report_id,
         fight_id,

--- a/crit_app/util/party_dps_distribution.py
+++ b/crit_app/util/party_dps_distribution.py
@@ -35,6 +35,7 @@ class SplitPartyRotation(KillTime):
     """Party rotation analysis split into a truncated segment and a clipping segment."""
 
     seconds_shortened: float
+    seconds_shortened_offset: float
     boss_hp: int
     truncated_damage_distribution: ArrayLike
     truncated_damage_support: ArrayLike
@@ -55,6 +56,8 @@ class PartyRotation(KillTime):
     party_id: str
     boss_hp: int
     active_dps_time: float
+    fight_duration: float
+    perform_kill_time_analysis: bool
     limit_break_events: pd.DataFrame
     party_mean: float
     party_std: float

--- a/fflogs_rotation/rotation.py
+++ b/fflogs_rotation/rotation.py
@@ -440,6 +440,9 @@ class ActionTable(object):
             )
             downtime = self.get_downtime(phase_response)
 
+            self.phase_start_time = phase_start_time
+            self.phase_end_time = phase_end_time
+
             self.fight_start_time = self.report_start_time + phase_start_time
             self.fight_end_time = self.report_start_time + phase_end_time
 


### PR DESCRIPTION
Party analysis by phase has some gotchas for the kill time analysis:

The kill time analysis uses duration the boss is alive, but only the phase duration, which includes downtime is available. This code finds the difference between the end of the phase when the boss dies, then adjusts the kill time analysis accordingly.

Kill time analyses are also skipped for phases with fixed durations.