### PR TITLE
Exclude certain enemies in fights

### DIFF
--- a/crit_app/db_setup.py
+++ b/crit_app/db_setup.py
@@ -20,22 +20,23 @@ if not (BLOB_URI / "error-logs").exists():
     (BLOB_URI / "error-logs").resolve().mkdir(parents=True)
 
 create_encounter_table = """
-create table if not exists encounter(
-    report_id TEXT NOT NULL,
-    fight_id INTEGER NOT NULL,
-    encounter_id INTEGER NOT NULL,
-    last_phase_index INTEGER,
-    encounter_name TEXT NOT NULL,
-    kill_time REAL NOT NULL,
-    player_name TEXT NOT NULL,
-    player_server TEXT,
-    player_id INTEGER NOT NULL,
-    pet_ids TEXT,
-    job TEXT NOT NULL,
-    role TEXT NOT NULL,
-    primary key (report_id, fight_id, player_id)
-)
-strict
+CREATE TABLE
+    encounter (
+        report_id TEXT NOT NULL,
+        fight_id INTEGER NOT NULL,
+        encounter_id INTEGER NOT NULL,
+        last_phase_index INTEGER,
+        encounter_name TEXT NOT NULL,
+        kill_time REAL NOT NULL,
+        player_name TEXT NOT NULL,
+        player_server TEXT,
+        player_id INTEGER NOT NULL,
+        pet_ids TEXT,
+        excluded_enemy_ids TEXT,
+        job TEXT NOT NULL,
+        role TEXT NOT NULL,
+        PRIMARY KEY (report_id, fight_id, player_id)
+    ) STRICT;
 """
 
 create_report_table = """

--- a/crit_app/figures.py
+++ b/crit_app/figures.py
@@ -14,7 +14,7 @@ from dash.dash_table import FormatTemplate
 from dash.dash_table.Format import Format, Scheme
 from plotly.graph_objs import Figure
 
-from crit_app.dmg_distribution import get_dps_dmg_percentile, summarize_actions
+from crit_app.dmg_distribution import get_dps_dmg_percentile
 
 
 def make_rotation_pdf_figure(
@@ -406,71 +406,6 @@ def make_action_pdfs_figure(
     fig.update_xaxes(range=[min(x_min) - (max(x_max) - min(x_min)) / 50, max(x_max)])
 
     return fig
-
-
-def make_action_table(
-    rotation_obj: Any, action_df: pd.DataFrame
-) -> List[dash_table.DataTable]:
-    """Create a table listing an action name, expected DPS, actual DPS dealt,.
-
-    and the corresponding percentile.
-
-    Parameters:
-        rotation_obj (Any): Rotation object from ffxiv_stats with damage distributions computed.
-        action_df (pd.DataFrame): DataFrame of actions, obtained from the function `create_action_df`, which depends on output from `damage_events`.
-
-    Returns:
-        List[dash_table.DataTable]: A list containing a Dash table with action, expected DPS, actual DPS, and percentile.
-    """
-    action_summary_df = summarize_actions(
-        action_df,
-        rotation_obj.unique_actions_distribution,
-        rotation_obj.active_dps_t,
-        rotation_obj.analysis_t,
-    ).sort_values("actual_dps_dealt", ascending=False)
-    action_summary_df = action_summary_df.rename(
-        columns={
-            "ability_name": "Action",
-            "dps_50th_percentile": "DPS 50th %",
-            "actual_dps_dealt": "Actual DPS",
-            "percentile": "Percentile",
-        }
-    )
-    columns = [
-        dict(
-            id="Action",
-            name="Action",
-        ),
-        dict(
-            id="DPS 50th %",
-            name="DPS 50th %",
-            type="numeric",
-            format=Format(precision=2, scheme=Scheme.decimal_integer),
-        ),
-        dict(
-            id="Actual DPS",
-            name="Actual DPS",
-            type="numeric",
-            format=Format(precision=2, scheme=Scheme.decimal_integer),
-        ),
-        dict(
-            id="Percentile",
-            name="Percentile",
-            type="numeric",
-            format=FormatTemplate.percentage(1),
-        ),
-    ]
-    print(action_summary_df.to_dict("records"))
-    action_summary_table = [
-        dash_table.DataTable(
-            data=action_summary_df.to_dict("records"),
-            columns=columns,
-            cell_selectable=False,
-            style_header={"backgroundColor": "rgb(48, 48, 48)", "color": "white"},
-            style_data={"backgroundColor": "rgb(50, 50, 50)", "color": "white"},
-        )
-    ]
-    return action_summary_table
 
 
 def make_kill_time_graph(

--- a/crit_app/job_data/encounter_data.py
+++ b/crit_app/job_data/encounter_data.py
@@ -75,6 +75,9 @@ boss_hp = {
     1072: 66146024,
 }
 
+# FFlogs periodically excludes damage to certain
+excluded_enemy_game_ids = {1079: [17828]}
+
 patch_times = {
     6.4: {"start": 1684836000000, "end": 1696327199999},
     6.5: {"start": 1696327200000, "end": 1719565299999},

--- a/crit_app/pages/party_analysis.py
+++ b/crit_app/pages/party_analysis.py
@@ -305,7 +305,7 @@ def load_job_rotation_figure(job_analysis_id: Optional[str], graph_type: str) ->
     with open(BLOB_URI / f"rotation-object-{job_analysis_id}.pkl", "rb") as f:
         rotation_object = pickle.load(f)
 
-    actions_df = rotation_object.actions_df
+    actions_df = rotation_object.filtered_actions_df
 
     action_dps = (
         actions_df[["ability_name", "amount"]].groupby("ability_name").sum()

--- a/crit_app/util/db.py
+++ b/crit_app/util/db.py
@@ -220,7 +220,7 @@ def update_encounter_table(db_rows):
         insert
         or replace into encounter
         values
-            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         db_rows,
     )
@@ -277,6 +277,7 @@ def read_player_analysis_info(
         select
             player_name,
             pet_ids,
+            excluded_enemy_ids,
             job,
             `role`,
             encounter_id,
@@ -290,12 +291,30 @@ def read_player_analysis_info(
     """,
         (report_id, fight_id, player_id),
     )
-    player_name, pet_ids, job, role, encounter_id, encounter_name = cur.fetchone()
+    (
+        player_name,
+        pet_ids,
+        excluded_enemy_ids,
+        job,
+        role,
+        encounter_id,
+        encounter_name,
+    ) = cur.fetchone()
     cur.close()
     con.close()
     if pet_ids is not None:
         pet_ids = literal_eval(pet_ids)
-    return player_name, pet_ids, job, role, encounter_id, encounter_name
+    if excluded_enemy_ids is not None:
+        excluded_enemy_ids = literal_eval(excluded_enemy_ids)
+    return (
+        player_name,
+        pet_ids,
+        excluded_enemy_ids,
+        job,
+        role,
+        encounter_id,
+        encounter_name,
+    )
 
 
 def compute_party_bonus(report_id: str, fight_id: int) -> str:
@@ -494,6 +513,7 @@ def retrieve_player_analysis_information(analysis_id: str) -> Dict[str, Any]:
         encounter.job as job,
         player_id,
         pet_ids,
+        excluded_enemy_ids,
         role,
         encounter_id,
         kill_time,
@@ -535,6 +555,9 @@ def retrieve_player_analysis_information(analysis_id: str) -> Dict[str, Any]:
 
     if result["pet_ids"] is not None:
         result["pet_ids"] = literal_eval(result["pet_ids"])
+
+    if result["excluded_enemy_ids"] is not None:
+        result["excluded_enemy_ids"] = literal_eval(result["excluded_enemy_ids"])
 
     return result
 


### PR DESCRIPTION
Add ability to specify game enemy IDs to exclude from analysis. Currently only happens to dark crystals in FRU

API call finds their IDs.
They get filtered out for damage variance analysis.